### PR TITLE
fix: 防止中文输入法输入英文时触发提交

### DIFF
--- a/src/views/Chat/index.vue
+++ b/src/views/Chat/index.vue
@@ -104,7 +104,7 @@ function addMessage(message: string, reversal = false) {
     </main>
     <footer class="p-4">
       <div class="flex items-center justify-between space-x-2">
-        <NInput v-model:value="value" :disabled="loading" placeholder="Type a message..." @keyup="handleEnter" />
+        <NInput v-model:value="value" :disabled="loading" placeholder="Type a message..." @keypress="handleEnter" />
         <NButton type="primary" :loading="loading" @click="handleSubmit">
           <template #icon>
             <Icon icon="ri:send-plane-fill" />


### PR DESCRIPTION
部分输入法支持中英文混输，输入过程中按空格选择中文，按回车把当前的英文直接上屏。

至少在Chrome浏览器中，会把输入法选英文词的回车作为keyup事件，导致未输入完成的句子被提交。改成监听keypress事件就没问题了。 其他浏览器未测试。