### PR TITLE
优化 docker 构建的镜像文件大小，添加自动化构建

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -1,0 +1,37 @@
+name: build_docker
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build_docker:
+    name: Build docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: 0x-jerry/chatgpt-web
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -15,7 +15,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: 0x-jerry/chatgpt-web
+          images: 0xjerry/chatgpt-web
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ COPY --from=builder /app/dist /app/public
 
 WORKDIR /app
 RUN npm install pnpm -g && pnpm install
-RUN pnpm run start
 
 EXPOSE 3002
+
+CMD ["pnpm", "run", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
-FROM node:lts
+# build front-end
+FROM node:lts AS builder
 
-# copy resource
-RUN mkdir /app
 COPY ./ /app
 WORKDIR /app
 
-# build
-RUN npm install pnpm -g
-RUN pnpm bootstrap
-WORKDIR /app/service
-RUN pnpm install
+RUN npm install pnpm -g && pnpm install && pnpm run build
+
+# service
+FROM node:lts
+
+COPY /service /app
+COPY --from=builder /app/dist /app/public
+
 WORKDIR /app
+RUN npm install pnpm -g && pnpm install
+RUN pnpm run start
 
-EXPOSE 1002
 EXPOSE 3002
-
-CMD ["/bin/bash","./start.sh"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build front-end
-FROM node:lts AS builder
+FROM node:lts-alpine AS builder
 
 COPY ./ /app
 WORKDIR /app
@@ -7,7 +7,7 @@ WORKDIR /app
 RUN npm install pnpm -g && pnpm install && pnpm run build
 
 # service
-FROM node:lts
+FROM node:lts-alpine
 
 COPY /service /app
 COPY --from=builder /app/dist /app/public

--- a/README.md
+++ b/README.md
@@ -109,6 +109,20 @@ docker build -t marlkiller/chatgpt-web .
 docker run -p 1002:1002 marlkiller/chatgpt-web
 ```
 
+## Docker compose
+
+```yml
+version: "3"
+
+service: 
+  - app:
+    image: 0xjerry/chatgpt-web
+    ports:
+      - 3002:3002
+    environment:
+      OPENAI_API_KEY: xxxxxx
+```
+
 ### 网页
 
 根目录下运行以下命令，然后将 `dist` 文件夹复制到你的托管服务器上

--- a/README.md
+++ b/README.md
@@ -116,11 +116,11 @@ version: "3"
 
 service: 
   - app:
-    image: 0xjerry/chatgpt-web
-    ports:
-      - 3002:3002
-    environment:
-      OPENAI_API_KEY: xxxxxx
+        image: 0xjerry/chatgpt-web
+        ports:
+        - 3002:3002
+        environment:
+        OPENAI_API_KEY: xxxxxx
 ```
 
 ### 网页

--- a/README.md
+++ b/README.md
@@ -112,15 +112,15 @@ docker run -p 1002:1002 marlkiller/chatgpt-web
 ## Docker compose
 
 ```yml
-version: "3"
+version: '3'
 
-service: 
+service:
   - app:
-        image: 0xjerry/chatgpt-web
-        ports:
-        - 3002:3002
-        environment:
-        OPENAI_API_KEY: xxxxxx
+    image: 0xjerry/chatgpt-web
+    ports:
+      - 3002:3002
+    environment:
+      OPENAI_API_KEY: xxxxxx
 ```
 
 ### 网页

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ docker run -p 1002:1002 marlkiller/chatgpt-web
 version: '3'
 
 service:
-  - app:
+  app:
     image: 0xjerry/chatgpt-web
     ports:
       - 3002:3002


### PR DESCRIPTION
新增一些优化和功能：

1. 自动构建 docker
2. 优化构建后的大小 image 的大小

自动化构建，需要自行修改一些配置项：

1. 需要修改 `build_docker.yml` 中的推送仓库
```yml
      - name: Docker meta
        id: meta
        uses: docker/metadata-action@v4
        with:
          images: 0xjerry/chatgpt-web # 需要修改，格式 `name/repo`
```

2. 需要在仓库的 secrets 里面添加 docker hub 的 name 和 token

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/14226737/219305332-5a6e069d-01a7-455b-86b2-e46f154394db.png">
