### PR TITLE
feat: 在电脑的小窗模式打开下可以通过 ctrl+enter 发送消息

### DIFF
--- a/src/views/chat/index.vue
+++ b/src/views/chat/index.vue
@@ -305,6 +305,12 @@ function handleEnter(event: KeyboardEvent) {
       handleSubmit()
     }
   }
+  else {
+    if (event.key === 'Enter' && event.ctrlKey) {
+      event.preventDefault()
+      handleSubmit()
+    }
+  }
 }
 
 function handleStop() {


### PR DESCRIPTION
在开发 mac menubar 插件的时候，打开网页会被识别为移动端，无法触发 enter 发送消息的功能。因此想增加一个 ctrl+enter 发送消息。