### PR TITLE
feat: 优化打字机模式显示新内容的逻辑

### DIFF
--- a/src/views/chat/hooks/useScroll.ts
+++ b/src/views/chat/hooks/useScroll.ts
@@ -7,6 +7,7 @@ interface ScrollReturn {
   scrollRef: Ref<ScrollElement>
   scrollToBottom: () => Promise<void>
   scrollToTop: () => Promise<void>
+	scrollToBottomIfAtBottom: () => Promise<void>
 }
 
 export function useScroll(): ScrollReturn {
@@ -24,9 +25,21 @@ export function useScroll(): ScrollReturn {
       scrollRef.value.scrollTop = 0
   }
 
+  const scrollToBottomIfAtBottom = async () => {
+		await nextTick()
+    if (scrollRef.value) {
+      const threshold = 50 // 阈值，表示滚动条到底部的距离阈值
+      const distanceToBottom = scrollRef.value.scrollHeight - scrollRef.value.scrollTop - scrollRef.value.clientHeight
+      if (distanceToBottom <= threshold) {
+        scrollRef.value.scrollTop = scrollRef.value.scrollHeight
+      }
+    }
+  }
+	
   return {
     scrollRef,
     scrollToBottom,
     scrollToTop,
+		scrollToBottomIfAtBottom,
   }
 }

--- a/src/views/chat/index.vue
+++ b/src/views/chat/index.vue
@@ -120,7 +120,7 @@ async function onConversation() {
         }
       },
     })
-    scrollToBottom()
+    scrollToBottomIfAtBottom()
   }
   catch (error: any) {
     const errorMessage = error?.message ?? t('common.wrong')

--- a/src/views/chat/index.vue
+++ b/src/views/chat/index.vue
@@ -24,7 +24,7 @@ const chatStore = useChatStore()
 useCopyCode()
 const { isMobile } = useBasicLayout()
 const { addChat, updateChat, updateChatSome, getChatByUuidAndIndex } = useChat()
-const { scrollRef, scrollToBottom } = useScroll()
+const { scrollRef, scrollToBottom, scrollToBottomIfAtBottom } = useScroll()
 
 const { uuid } = route.params as { uuid: string }
 
@@ -113,7 +113,7 @@ async function onConversation() {
               requestOptions: { prompt: message, options: { ...options } },
             },
           )
-          scrollToBottom()
+          scrollToBottomIfAtBottom()
         }
         catch (error) {
           //


### PR DESCRIPTION
打字机模式显示新内容时，如果此时滚动条在底部则保持滚动条始终在底部，若滚动条不在底部也不会强制滚动到底部。
目的是允许用户在生成新内容时查看以往的内容，类似官方网页 ChatGPT 的效果。#349 
![VID_20230308_184832 (2)](https://user-images.githubusercontent.com/71998166/223694923-d7116395-0f69-4bc8-a909-40f0e9273390.gif)