### PR TITLE
fix: reset history title on clear

### DIFF
--- a/src/store/modules/chat/index.ts
+++ b/src/store/modules/chat/index.ts
@@ -165,6 +165,7 @@ export const useChatStore = defineStore('chat-store', {
       if (!uuid || uuid === 0) {
         if (this.chat.length) {
           this.chat[0].data = []
+          this.history[0].title = 'New Chat'
           this.recordState()
         }
         return
@@ -173,6 +174,7 @@ export const useChatStore = defineStore('chat-store', {
       const index = this.chat.findIndex(item => item.uuid === uuid)
       if (index !== -1) {
         this.chat[index].data = []
+        this.history[index].title = 'New Chat'
         this.recordState()
       }
     },


### PR DESCRIPTION
当清空聊天记录时，同时重置历史列表的标题，以响应新聊天的更新