### PR TITLE
fix line end with new-line in some backend

### DIFF
--- a/src/views/chat/index.vue
+++ b/src/views/chat/index.vue
@@ -102,7 +102,7 @@ async function onConversation() {
           const xhr = event.target
           const { responseText } = xhr
           // Always process the final line
-          const lastIndex = responseText.lastIndexOf('\n')
+          const lastIndex = responseText.lastIndexOf('\n', responseText.length - 2)
           let chunk = responseText
           if (lastIndex !== -1)
             chunk = responseText.substring(lastIndex)

--- a/src/views/chat/index.vue
+++ b/src/views/chat/index.vue
@@ -232,7 +232,7 @@ async function onRegenerate(index: number) {
           const xhr = event.target
           const { responseText } = xhr
           // Always process the final line
-          const lastIndex = responseText.lastIndexOf('\n')
+          const lastIndex = responseText.lastIndexOf('\n', responseText.length - 2)
           let chunk = responseText
           if (lastIndex !== -1)
             chunk = responseText.substring(lastIndex)


### PR DESCRIPTION
In backend with golang (like https://github.com/sashabaranov/go-openai), the responseText always has a '\n'.