### PR TITLE
fix: Prompt商店在线导入可以导入两种recommend.json里提到的模板 (#516)

### DIFF
--- a/src/assets/recommend.json
+++ b/src/assets/recommend.json
@@ -1,8 +1,14 @@
 [
   {
+    "key": "chatgpt-prompt-collection",
+    "desc": "Nothing1024收集整理的prompts",
+    "downloadUrl": "https://raw.githubusercontent.com/Nothing1024/chatgpt-prompt-collection/main/awesome-chatgpt-prompts-zh.json",
+    "url": "https://github.com/Nothing1024/chatgpt-prompt-collection"
+  },
+  {
     "key": "awesome-chatgpt-prompts-zh",
     "desc": "ChatGPT 中文调教指南",
-    "downloadUrl": "https://raw.githubusercontent.com/Nothing1024/chatgpt-prompt-collection/main/awesome-chatgpt-prompts-zh.json",
+    "downloadUrl": "https://raw.githubusercontent.com/PlexPt/awesome-chatgpt-prompts-zh/main/prompts-zh.json",
     "url": "https://github.com/PlexPt/awesome-chatgpt-prompts-zh"
   }
 ]

--- a/src/components/common/PromptStore/index.vue
+++ b/src/components/common/PromptStore/index.vue
@@ -144,22 +144,39 @@ const clearPromptTemplate = () => {
 const importPromptTemplate = () => {
   try {
     const jsonData = JSON.parse(tempPromptValue.value)
+    let key = ''
+    let value = ''
+    // 可以扩展加入更多模板字典的key
+    if ('key' in jsonData[0]) {
+      key = 'key'
+      value = 'value'
+    }
+    else if ('act' in jsonData[0]) {
+      key = 'act'
+      value = 'prompt'
+    }
+    else {
+      // 不支持的字典的key防止导入 以免破坏prompt商店打开
+      message.warning('prompt key not supported.')
+      throw new Error('prompt key not supported.')
+    }
+
     for (const i of jsonData) {
       let safe = true
       for (const j of promptList.value) {
-        if (j.key === i.key) {
-          message.warning(`因标题重复跳过：${i.key}`)
+        if (j.key === i[key]) {
+          message.warning(`因标题重复跳过：${i[key]}`)
           safe = false
           break
         }
-        if (j.value === i.value) {
-          message.warning(`因内容重复跳过：${i.key}`)
+        if (j.value === i[value]) {
+          message.warning(`因内容重复跳过：${i[key]}`)
           safe = false
           break
         }
       }
       if (safe)
-        promptList.value.unshift({ key: i.key, value: i.value } as never)
+        promptList.value.unshift({ key: i[key], value: i[value] } as never)
     }
     message.success('导入成功')
     changeShowModal('')

--- a/src/components/common/PromptStore/index.vue
+++ b/src/components/common/PromptStore/index.vue
@@ -209,6 +209,7 @@ const downloadPromptTemplate = async () => {
       }).then(() => {
         importPromptTemplate()
       })
+    downloadURL.value = ''
   }
   catch {
     message.error('网络导入出现问题，请检查网络状态与 JSON 文件有效性')


### PR DESCRIPTION
如[#516](https://github.com/Chanzhaoyu/chatgpt-web/issues/516#issue-1620061293)所提到的，recommend.json里有两个repo，每个repo用的模板的字典key是不一样的。虽然只会导入一种，但如有我这样想自己做一份模板自用的可能会用错模板。导入另一种不支持的模板会导致prompt商店无法再次打开（点商店无反应），所以干脆就把两个repo的模板都支持了。

另加了点击“下载”按钮清空输入框，方便连续从不同repo导入。虽然原来也可以连续导入，点第二个repo的“+”号会自动覆盖前面输入的URL，但是在手机上如果输入框不够长看不到URL改变了（URL前半部份一样的），所以点“下载”之后自动清空输入框，再次导入再自动填入地址符合直觉。