### PR TITLE
fix: 修复在线导入json

### DIFF
--- a/src/components/common/PromptStore/index.vue
+++ b/src/components/common/PromptStore/index.vue
@@ -168,8 +168,6 @@ const importPromptTemplate = () => {
     }
 
     for (const i of jsonData) {
-      if (!('key' in i) || !('value' in i))
-        throw new Error(t('store.importError'))
       let safe = true
       for (const j of promptList.value) {
         if (j.key === i[key]) {

--- a/src/components/common/PromptStore/index.vue
+++ b/src/components/common/PromptStore/index.vue
@@ -185,6 +185,13 @@ const importPromptTemplate = () => {
         promptList.value.unshift({ key: i[key], value: i[value] } as never)
     }
     message.success(t('common.importSuccess'))
+    // TODO：
+    // 从原始版本开始导入在线模板就会有黑色蒙版出现，其实是弹出（一个看不见的）对话框
+    // 在大佬改进界面后，弹出的不再是黑色蒙版，无内容的对话框也会出现了
+    // 对话框会出现是因为下面"changeShowModal"会改变"showModal"值为true
+    // 故这里使用简单粗暴的方法先改"showModal"为false，再调用"changeShowModal"就不会出现对话框
+    // 因避免改动原始代码逻辑，这个修复比较保险，后期应根据原作意图把这些重构
+    showModal.value = true
     changeShowModal('')
   }
   catch {


### PR DESCRIPTION
原因在此：[link](https://github.com/Chanzhaoyu/chatgpt-web/pull/521#issuecomment-1465208190),  只能留一种导入检查方式，并修复 #564 的issue。

改动如下：
1. 保留导入两种模板的功能。移除使用一种模板的方式。
2. 之前一直有的屏幕变黑问题，其实是有一个隐藏对话框会在导入之后出现，用了最简单粗暴的方式解决了弹对话框问题。目前是不改动任何原逻辑的补丁，我也留了注释，以后可以通过代码重构解决。

效果如下：
![example gif](https://i.ibb.co/k43pffL/example.gif)