### PR TITLE
fix: To make the scrollbar style compatible with naive-ui

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,15 @@
 import { createApp } from 'vue'
 import App from './App.vue'
 import { setupI18n } from './locales'
-import { setupAssets } from './plugins'
+import { setupAssets, setupScrollbarStyle } from './plugins'
 import { setupStore } from './store'
 import { setupRouter } from './router'
 
 async function bootstrap() {
   const app = createApp(App)
   setupAssets()
+
+  setupScrollbarStyle()
 
   setupStore(app)
 

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,3 +1,4 @@
 import setupAssets from './assets'
+import setupScrollbarStyle from './scrollbarStyle'
 
-export { setupAssets }
+export { setupAssets, setupScrollbarStyle }

--- a/src/plugins/scrollbarStyle.ts
+++ b/src/plugins/scrollbarStyle.ts
@@ -1,0 +1,28 @@
+import { darkTheme, lightTheme } from 'naive-ui'
+
+const setupScrollbarStyle = () => {
+  const style = document.createElement('style')
+  const styleContent = `
+    ::-webkit-scrollbar {
+      background-color: transparent;
+      width: ${lightTheme.Scrollbar.common?.scrollbarWidth};
+    }
+    ::-webkit-scrollbar-thumb {
+      background-color: ${lightTheme.Scrollbar.common?.scrollbarColor};
+      border-radius: ${lightTheme.Scrollbar.common?.scrollbarBorderRadius};
+    }
+    html.dark ::-webkit-scrollbar {
+      background-color: transparent;
+      width: ${darkTheme.Scrollbar.common?.scrollbarWidth};
+    }
+    html.dark ::-webkit-scrollbar-thumb {
+      background-color: ${darkTheme.Scrollbar.common?.scrollbarColor};
+      border-radius: ${darkTheme.Scrollbar.common?.scrollbarBorderRadius};
+    }
+  `
+
+  style.innerHTML = styleContent
+  document.head.appendChild(style)
+}
+
+export default setupScrollbarStyle


### PR DESCRIPTION
To adapt the scrollbar for both light and dark mode.

<img width="1200" alt="Xnip2023-03-16_10-59-02" src="https://user-images.githubusercontent.com/17695989/225501474-a9ccfbda-5fe9-421e-a5c3-af4c20ef7497.png">
<img width="1195" alt="Xnip2023-03-16_10-59-25" src="https://user-images.githubusercontent.com/17695989/225501496-c89c841c-e730-4cbe-8b7d-d4be0033e210.png">
