### PR TITLE
AccessToken 模式支持 gpt-4

### DIFF
--- a/service/src/chatgpt/index.ts
+++ b/service/src/chatgpt/index.ts
@@ -68,11 +68,13 @@ let api: ChatGPTAPI | ChatGPTUnofficialProxyAPI
     apiModel = 'ChatGPTAPI'
   }
   else {
+    const OPENAI_API_MODEL = process.env.OPENAI_API_MODEL
     const options: ChatGPTUnofficialProxyAPIOptions = {
       accessToken: process.env.OPENAI_ACCESS_TOKEN,
       debug: false,
     }
-
+    if (OPENAI_API_MODEL && typeof OPENAI_API_MODEL === 'string')
+      options.model = OPENAI_API_MODEL
     if (process.env.SOCKS_PROXY_HOST && process.env.SOCKS_PROXY_PORT) {
       const agent = new SocksProxyAgent({
         hostname: process.env.SOCKS_PROXY_HOST,


### PR DESCRIPTION
原先的环境变量 OPENAI_API_MODEL  只支持 ApiKey 模式，现在配置成对 AccessToken 模式也生效。默认情况走默认的模型。