### PR TITLE
feat: 增加 ChatGPTUnofficialProxyAPI 的模型自定义配置

### DIFF
--- a/service/src/chatgpt/index.ts
+++ b/service/src/chatgpt/index.ts
@@ -68,10 +68,13 @@ let api: ChatGPTAPI | ChatGPTUnofficialProxyAPI
     apiModel = 'ChatGPTAPI'
   }
   else {
+    const OPENAI_API_MODEL = process.env.OPENAI_API_MODEL
     const options: ChatGPTUnofficialProxyAPIOptions = {
       accessToken: process.env.OPENAI_ACCESS_TOKEN,
       debug: false,
     }
+    if (OPENAI_API_MODEL && typeof OPENAI_API_MODEL === 'string')
+      options.model = OPENAI_API_MODEL
 
     if (process.env.SOCKS_PROXY_HOST && process.env.SOCKS_PROXY_PORT) {
       const agent = new SocksProxyAgent({


### PR DESCRIPTION
原先的环境变量 OPENAI_API_MODEL 只支持 ApiKey 模式，现在配置成对 AccessToken 模式也生效。默认情况走默认的模型，填写 gpt-4 时会走 gpt-4 模型。