### PR TITLE
feat: 添加显示用于原文的选项

### DIFF
--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -46,6 +46,8 @@ export default {
     deleteMessageConfirm: 'Are you sure to delete this message?',
     deleteHistoryConfirm: 'Are you sure to clear this history?',
     clearHistoryConfirm: 'Are you sure to clear chat history?',
+    preview: 'Preview',
+    showRawText: 'Show as raw text',
   },
   setting: {
     setting: 'Setting',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -46,6 +46,8 @@ export default {
     deleteMessageConfirm: '是否删除此消息?',
     deleteHistoryConfirm: '确定删除此记录?',
     clearHistoryConfirm: '确定清空聊天记录?',
+    preview: '预览',
+    showRawText: '显示原文',
   },
   setting: {
     setting: '设置',

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -46,6 +46,8 @@ export default {
     deleteMessageConfirm: '是否刪除此訊息?',
     deleteHistoryConfirm: '確定刪除此紀錄?',
     clearHistoryConfirm: '確定清除紀錄?',
+    preview: '預覽',
+    showRawText: '顯示原文',
   },
   setting: {
     setting: '設定',

--- a/src/views/chat/components/Message/Text.vue
+++ b/src/views/chat/components/Message/Text.vue
@@ -12,6 +12,7 @@ interface Props {
   error?: boolean
   text?: string
   loading?: boolean
+  asRawText?: boolean
 }
 
 const props = defineProps<Props>()
@@ -49,7 +50,7 @@ const wrapClass = computed(() => {
 
 const text = computed(() => {
   const value = props.text ?? ''
-  if (!props.inversion)
+  if (!props.asRawText)
     return mdi.render(value)
   return value
 })
@@ -68,7 +69,7 @@ defineExpose({ textRef })
     </template>
     <template v-else>
       <div ref="textRef" class="leading-relaxed break-words">
-        <div v-if="!inversion" class="markdown-body" v-html="text" />
+        <div v-if="!asRawText" class="markdown-body" v-html="text" />
         <div v-else class="whitespace-pre-wrap" v-text="text" />
       </div>
     </template>

--- a/src/views/chat/components/Message/Text.vue
+++ b/src/views/chat/components/Message/Text.vue
@@ -44,7 +44,7 @@ const wrapClass = computed(() => {
     isMobile.value ? 'p-2' : 'px-3 py-2',
     props.inversion ? 'bg-[#d2f9d1]' : 'bg-[#f4f6f8]',
     props.inversion ? 'dark:bg-[#a1dc95]' : 'dark:bg-[#1e1e20]',
-    props.inversion ? 'request' : 'reply',
+    props.inversion ? 'message-request' : 'message-reply',
     { 'text-red-500': props.error },
   ]
 })
@@ -70,7 +70,10 @@ defineExpose({ textRef })
     </template>
     <template v-else>
       <div ref="textRef" class="leading-relaxed break-words">
-        <div v-if="!asRawText" class="markdown-body" v-html="text" />
+        <div v-if="!inversion">
+          <div v-if="!asRawText" class="markdown-body" v-html="text" />
+          <div v-else class="raw-text" v-text="text" />
+        </div>
         <div v-else class="whitespace-pre-wrap" v-text="text" />
       </div>
     </template>

--- a/src/views/chat/components/Message/Text.vue
+++ b/src/views/chat/components/Message/Text.vue
@@ -44,6 +44,7 @@ const wrapClass = computed(() => {
     isMobile.value ? 'p-2' : 'px-3 py-2',
     props.inversion ? 'bg-[#d2f9d1]' : 'bg-[#f4f6f8]',
     props.inversion ? 'dark:bg-[#a1dc95]' : 'dark:bg-[#1e1e20]',
+    props.inversion ? 'request' : 'reply',
     { 'text-red-500': props.error },
   ]
 })

--- a/src/views/chat/components/Message/index.vue
+++ b/src/views/chat/components/Message/index.vue
@@ -1,5 +1,5 @@
 <script setup lang='ts'>
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { NDropdown } from 'naive-ui'
 import AvatarComponent from './Avatar.vue'
 import TextComponent from './Text.vue'
@@ -29,7 +29,14 @@ const { iconRender } = useIconRender()
 
 const textRef = ref<HTMLElement>()
 
-const options = [
+const asRawText = ref(props.inversion)
+
+const options = computed(() => [
+  {
+    label: asRawText.value ? t('chat.preview') : t('chat.showRawText'),
+    key: 'toggleRenderType',
+    icon: iconRender({ icon: asRawText.value ? 'ic:outline-code-off' : 'ic:outline-code' }),
+  },
   {
     label: t('chat.copy'),
     key: 'copyText',
@@ -40,12 +47,15 @@ const options = [
     key: 'delete',
     icon: iconRender({ icon: 'ri:delete-bin-line' }),
   },
-]
+])
 
-function handleSelect(key: 'copyRaw' | 'copyText' | 'delete') {
+function handleSelect(key: 'copyRaw' | 'copyText' | 'delete' | 'toggleRenderType') {
   switch (key) {
     case 'copyText':
       copyText({ text: props.text ?? '' })
+      return
+    case 'toggleRenderType':
+      asRawText.value = !asRawText.value
       return
     case 'delete':
       emit('delete')
@@ -79,6 +89,7 @@ function handleRegenerate() {
           :error="error"
           :text="text"
           :loading="loading"
+          :as-raw-text="asRawText"
         />
         <div class="flex flex-col">
           <button

--- a/src/views/chat/components/Message/index.vue
+++ b/src/views/chat/components/Message/index.vue
@@ -31,25 +31,32 @@ const textRef = ref<HTMLElement>()
 
 const asRawText = ref(props.inversion)
 
-const options = computed(() => [
-  {
-    label: asRawText.value ? t('chat.preview') : t('chat.showRawText'),
-    key: 'toggleRenderType',
-    icon: iconRender({ icon: asRawText.value ? 'ic:outline-code-off' : 'ic:outline-code' }),
-  },
-  {
-    label: t('chat.copy'),
-    key: 'copyText',
-    icon: iconRender({ icon: 'ri:file-copy-2-line' }),
-  },
-  {
-    label: t('common.delete'),
-    key: 'delete',
-    icon: iconRender({ icon: 'ri:delete-bin-line' }),
-  },
-])
+const options = computed(() => {
+  const common = [
+    {
+      label: t('chat.copy'),
+      key: 'copyText',
+      icon: iconRender({ icon: 'ri:file-copy-2-line' }),
+    },
+    {
+      label: t('common.delete'),
+      key: 'delete',
+      icon: iconRender({ icon: 'ri:delete-bin-line' }),
+    },
+  ]
 
-function handleSelect(key: 'copyRaw' | 'copyText' | 'delete' | 'toggleRenderType') {
+  if (!props.inversion) {
+    common.unshift({
+      label: asRawText.value ? t('chat.preview') : t('chat.showRawText'),
+      key: 'toggleRenderType',
+      icon: iconRender({ icon: asRawText.value ? 'ic:outline-code-off' : 'ic:outline-code' }),
+    })
+  }
+
+  return common
+})
+
+function handleSelect(key: 'copyText' | 'delete' | 'toggleRenderType') {
   switch (key) {
     case 'copyText':
       copyText({ text: props.text ?? '' })

--- a/src/views/chat/components/Message/style.less
+++ b/src/views/chat/components/Message/style.less
@@ -1,5 +1,3 @@
-@import url('/src/styles/lib/github-markdown.less');
-
 .markdown-body {
 	background-color: transparent;
 	font-size: 14px;
@@ -47,10 +45,11 @@
 			align-items: center;
 			color: #b3b3b3;
 
-			&__copy{
+			&__copy {
 				cursor: pointer;
 				margin-left: 0.5rem;
 				user-select: none;
+
 				&:hover {
 					color: #65a665;
 				}
@@ -60,22 +59,13 @@
 
 }
 
-html .markdown-body {
-
-	h1,h2,h3,h4 {
-		border: none;
-	}
-}
-
 html.dark {
 
-	/* 用户的输入始终使用亮色主题的 Markdown */
-   	.request .markdown-body:extend(html .markdown-body) {
-		--color-canvas-default: #0d1117;
-    }
-
-	.reply .whitespace-pre-wrap {
-		color: var(--n-text-color);
+	.message-reply {
+		.raw-text {
+			white-space: pre-wrap;
+			color: var(--n-text-color);
+		}
 	}
 
 	.highlight pre,

--- a/src/views/chat/components/Message/style.less
+++ b/src/views/chat/components/Message/style.less
@@ -1,3 +1,5 @@
+@import url('/src/styles/lib/github-markdown.less');
+
 .markdown-body {
 	background-color: transparent;
 	font-size: 14px;
@@ -55,9 +57,26 @@
 			}
 		}
 	}
+
+}
+
+html .markdown-body {
+
+	h1,h2,h3,h4 {
+		border: none;
+	}
 }
 
 html.dark {
+
+	/* 用户的输入始终使用亮色主题的 Markdown */
+   	.request .markdown-body:extend(html .markdown-body) {
+		--color-canvas-default: #0d1117;
+    }
+
+	.reply .whitespace-pre-wrap {
+		color: var(--n-text-color);
+	}
 
 	.highlight pre,
 	pre {


### PR DESCRIPTION
最终的功能大概是这样子：

* 在弹出的菜单里添加一个选项来显示原文：
   
   |  渲染结果 |  显示原文 |
   |:--|:--|
  |![image](https://user-images.githubusercontent.com/32430186/226089733-7719b414-2fbf-4892-90a1-72bb6a2671d6.png)|![image](https://user-images.githubusercontent.com/32430186/226089766-0b03452a-340b-473a-9e64-40300c1a2a98.png)|

* 输入的内容会以 Markdown 渲染（这样整体观感会和谐一些）
  
  ![image](https://user-images.githubusercontent.com/32430186/226089799-3b490879-02ac-4c59-b842-637a2d5563ae.png)

Closes #671 
