### PR TITLE
fix: 当用gpt-4的API时增加可用的Max Tokens

### DIFF
--- a/service/src/chatgpt/index.ts
+++ b/service/src/chatgpt/index.ts
@@ -43,6 +43,19 @@ let api: ChatGPTAPI | ChatGPTUnofficialProxyAPI
       debug: true,
     }
 
+    // increase max token limit if use gpt-4
+    if (model.toLowerCase().includes('gpt-4')) {
+      // if use 32k model
+      if (model.toLowerCase().includes('32k')) {
+        options.maxModelTokens = 32768
+        options.maxResponseTokens = 8192
+      }
+      else {
+        options.maxModelTokens = 8192
+        options.maxResponseTokens = 2048
+      }
+    }
+
     if (isNotEmptyString(process.env.OPENAI_API_BASE_URL))
       options.apiBaseUrl = process.env.OPENAI_API_BASE_URL
 


### PR DESCRIPTION
已经有人收到gpt-4的邀请了(#706)，我最近也收到了。当OPENAI_API_MODEL填gpt-4相关的模型时，可以自动更改api的选项。虽然不一定每次都用得到，但临时有需求的话可以总结长文章、文献、进行长对话了。