### PR TITLE
chore: 显示原文时使用 .whitespace-pre-wrap

### DIFF
--- a/src/views/chat/components/Message/Text.vue
+++ b/src/views/chat/components/Message/Text.vue
@@ -72,7 +72,7 @@ defineExpose({ textRef })
       <div ref="textRef" class="leading-relaxed break-words">
         <div v-if="!inversion">
           <div v-if="!asRawText" class="markdown-body" v-html="text" />
-          <div v-else class="raw-text" v-text="text" />
+          <div v-else class="whitespace-pre-wrap" v-text="text" />
         </div>
         <div v-else class="whitespace-pre-wrap" v-text="text" />
       </div>

--- a/src/views/chat/components/Message/style.less
+++ b/src/views/chat/components/Message/style.less
@@ -62,7 +62,7 @@
 html.dark {
 
 	.message-reply {
-		.raw-text {
+		.whitespace-pre-wrap {
 			white-space: pre-wrap;
 			color: var(--n-text-color);
 		}


### PR DESCRIPTION
显示 ChatGPT 输出的原文时保留空格和换行