### PR TITLE
fix: ESM error

### DIFF
--- a/service/package.json
+++ b/service/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "start": "esno ./src/index.ts",
     "dev": "esno watch ./src/index.ts",
-    "prod": "esno ./build/index.js",
+    "prod": "node ./build/index.mjs",
     "build": "pnpm clean && tsup",
     "clean": "rimraf build",
     "lint": "eslint .",

--- a/service/src/chatgpt/index.ts
+++ b/service/src/chatgpt/index.ts
@@ -3,13 +3,15 @@ import 'isomorphic-fetch'
 import type { ChatGPTAPIOptions, ChatMessage, SendMessageOptions } from 'chatgpt'
 import { ChatGPTAPI, ChatGPTUnofficialProxyAPI } from 'chatgpt'
 import { SocksProxyAgent } from 'socks-proxy-agent'
-import { HttpsProxyAgent } from 'https-proxy-agent'
+import httpsProxyAgent from 'https-proxy-agent'
 import fetch from 'node-fetch'
 import axios from 'axios'
 import { sendResponse } from '../utils'
 import { isNotEmptyString } from '../utils/is'
 import type { ApiModel, ChatContext, ChatGPTUnofficialProxyAPIOptions, ModelConfig } from '../types'
 import type { RequestOptions } from './types'
+
+const { HttpsProxyAgent } = httpsProxyAgent
 
 dotenv.config()
 

--- a/service/tsup.config.ts
+++ b/service/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: ['src/index.ts'],
   outDir: 'build',
   target: 'es2020',
-  format: ['cjs'],
+  format: ['esm'],
   splitting: false,
   sourcemap: true,
   minify: false,


### PR DESCRIPTION
This pull request changes service compilation format to ESM and fix error when importing `https-proxy-agent`. `esno` should not be used in production as it hides ESM compatibility errors.

Types do not indicate this issue, I'm not sure if this is due to `esModuleInterop`, `tsup` or wrong types from `https-proxy-agent`, but it probably doesn't matter.