### PR TITLE
fix: 反向代理限流失效

### DIFF
--- a/service/src/index.ts
+++ b/service/src/index.ts
@@ -82,5 +82,6 @@ router.post('/verify', async (req, res) => {
 
 app.use('', router)
 app.use('/api', router)
+app.set('trust proxy', 1)
 
 app.listen(3002, () => globalThis.console.log('Server is running on port 3002'))


### PR DESCRIPTION
https://docs.colyseus.io/zh_hk/colyseus/how-to/rate-limit/

使用nginx限流会只识别为服务器ip，需启用trust proxy