### PR TITLE
fix: missing VITE_GLOB_API_URL when docker build, fixed #690 #717 #

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ node_modules
 Dockerfile
 .*
 */.*
+!.env


### PR DESCRIPTION
编译的时候 `.env` 文件被 `.dockerignore`  忽略了，需要排除 `.env` 文件