### PR TITLE
feat(api): 增加多 apikey 和 accseeToken 支持

### DIFF
--- a/service/.env.example
+++ b/service/.env.example
@@ -16,6 +16,12 @@ API_REVERSE_PROXY=
 # timeout
 TIMEOUT_MS=100000
 
+# 多apikey请求API返回429时的最大重试次数，默认为key的数量
+MAX_RETRY=
+
+# 多apikey请求API返回429时的重试间隔，默认为1秒
+RETRY_INTERVAL_MS=
+
 # Rate Limit
 MAX_REQUEST_PER_HOUR=
 

--- a/service/src/utils/index.ts
+++ b/service/src/utils/index.ts
@@ -40,6 +40,6 @@ export function loadBalancer<T>(arr: T[], strategy = 'random') {
     case 'random':
       return () => arr[Math.floor(Math.random() * arr.length)]
     case 'polling':
-      return (i => () => arr[i++ % arr.length])(0)
+      return (i => () => arr[i++ % arr.length])(Math.floor(Math.random() * arr.length))
   }
 }

--- a/service/src/utils/index.ts
+++ b/service/src/utils/index.ts
@@ -32,10 +32,13 @@ export function parseKeys(keys: string) {
  * 由数组和负载均衡策略生成一个负载均衡函数
  * @note 该函数将数组参数捕获为闭包，更改数组不会影响该函数生成的函数的表现；如果需要实时更新数组，需要重新调用该函数
  * @param arr 任意类型的数组
- * @param strategy 负载均衡策略，可选值：random, polling, 默认为 random。random 策略适合 serverless 这样的无状态场景
+ * @param strategy 负载均衡策略，可选值：random, polling, 默认为 polling
  * @returns 一个无参数的函数，每次调用返回数组中的一个元素
  */
-export function loadBalancer<T>(arr: T[], strategy = 'random') {
+export function loadBalancer<T>(arr: T[], strategy = 'polling') {
+  if (arr.length === 1)
+    return () => arr[0]
+
   switch (strategy.toLowerCase()) {
     case 'random':
       return () => arr[Math.floor(Math.random() * arr.length)]
@@ -43,3 +46,5 @@ export function loadBalancer<T>(arr: T[], strategy = 'random') {
       return (i => () => arr[i++ % arr.length])(Math.floor(Math.random() * arr.length))
   }
 }
+
+export const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))

--- a/service/src/utils/index.ts
+++ b/service/src/utils/index.ts
@@ -20,3 +20,25 @@ export function sendResponse<T>(options: SendResponseOptions<T>) {
     status: options.type,
   })
 }
+
+export function parseKeys(keys: string) {
+  return keys
+    .split(/\s*[,\n]\s*/)
+    .filter(k => /sk-\w{48}/.test(k))
+}
+
+/**
+ * 由数组和负载均衡策略生成一个负载均衡函数
+ * @note 该函数将数组参数捕获为闭包，更改数组不会影响该函数生成的函数的表现；如果需要实时更新数组，需要重新调用该函数
+ * @param arr 任意类型的数组
+ * @param strategy 负载均衡策略，可选值：random, polling, 默认为 random。random 策略适合 serverless 这样的无状态场景
+ * @returns 一个无参数的函数，每次调用返回数组中的一个元素
+ */
+export function loadBalancer<T>(arr: T[], strategy = 'random') {
+  switch (strategy.toLowerCase()) {
+    case 'random':
+      return () => arr[Math.floor(Math.random() * arr.length)]
+    case 'polling':
+      return (i => () => arr[i++ % arr.length])(0)
+  }
+}

--- a/service/src/utils/index.ts
+++ b/service/src/utils/index.ts
@@ -23,8 +23,9 @@ export function sendResponse<T>(options: SendResponseOptions<T>) {
 
 export function parseKeys(keys: string) {
   return keys
-    .split(/\s*[,\n]\s*/)
-    .filter(k => /sk-\w{48}/.test(k))
+    ? keys
+      .split(/\s*[,\n]\s*/)
+    : []
 }
 
 /**


### PR DESCRIPTION
环境变量 OPENAI_API_KEY 和 OPENAI_ACCESS_TOKEN 可以以半角逗号 "," 或 换行符 "\n" 进行分隔
可选 random 和 polling 两种负载均衡策略
多 apikey 时不再支持查询余额，将直接返回"-"

resolve https://github.com/Chanzhaoyu/chatgpt-web/issues/740 https://github.com/Chanzhaoyu/chatgpt-web/issues/773 https://github.com/Chanzhaoyu/chatgpt-web/issues/821 https://github.com/Chanzhaoyu/chatgpt-web/issues/923

2023/03/28 更新：
![image](https://user-images.githubusercontent.com/51076594/228256281-409b7310-9d22-46cf-b2e5-fee7dfbf96f6.png)
