### PR TITLE
Update index.ts

### DIFF
--- a/service/src/index.ts
+++ b/service/src/index.ts
@@ -84,4 +84,4 @@ app.use('', router)
 app.use('/api', router)
 app.set('trust proxy', 1)
 
-app.listen(3002, () => globalThis.console.log('Server is running on port 3002'))
+app.listen(3002, '0.0.0.0',() => globalThis.console.log('Server is running on port 3002'))


### PR DESCRIPTION
如果不设置一个IPV4的any地址，如果运行的服务器有IPV6和IPV4地址，则后端会绑定在IPV6的any地址上 导致前端无法连上后端
前端是设置了一个IPV4的any地址