### PR TITLE
bugfix 空引用显示undefined

### DIFF
--- a/src/views/chat/index.vue
+++ b/src/views/chat/index.vue
@@ -128,7 +128,7 @@ async function onConversation() {
               dataSources.value.length - 1,
               {
                 dateTime: new Date().toLocaleString(),
-                text: lastText + data.text ?? '',
+                text: lastText + (data.text ?? ''),
                 inversion: false,
                 error: false,
                 loading: true,


### PR DESCRIPTION
当前如果返回的data.text是undefined, 此时直接做连接操作，会导致得到'undefined'字符串，不符合预期

例如，在返回Unauthorized状态时，此时会返回以下回复
`
undefined
[Error: 无访问权限 | No access rights]
`