### PR TITLE
chore：去掉API_REVERSE_PROXY硬编码默认值，改为配置文件配置默认值

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       # API模型，可选，设置 OPENAI_API_KEY 时可用
       OPENAI_API_MODEL:
       # 反向代理，可选
-      API_REVERSE_PROXY:
+      API_REVERSE_PROXY: https://bypass.churchless.tech/api/conversation
       # 访问权限密钥，可选
       AUTH_SECRET_KEY:
       # 每小时最大请求次数，可选，默认无限

--- a/service/.env.example
+++ b/service/.env.example
@@ -16,7 +16,7 @@ OPENAI_API_DISABLE_DEBUG=
 # Reverse Proxy - Available on accessToken
 # Default: https://bypass.churchless.tech/api/conversation
 # More: https://github.com/transitive-bullshit/chatgpt-api#reverse-proxy
-API_REVERSE_PROXY=
+API_REVERSE_PROXY=https://bypass.churchless.tech/api/conversation
 
 # timeout
 TIMEOUT_MS=100000

--- a/service/src/chatgpt/index.ts
+++ b/service/src/chatgpt/index.ts
@@ -78,9 +78,8 @@ let api: ChatGPTAPI | ChatGPTUnofficialProxyAPI
     if (isNotEmptyString(OPENAI_API_MODEL))
       options.model = OPENAI_API_MODEL
 
-    options.apiReverseProxyUrl = isNotEmptyString(process.env.API_REVERSE_PROXY)
-      ? process.env.API_REVERSE_PROXY
-      : 'https://bypass.churchless.tech/api/conversation'
+		if (isNotEmptyString(process.env.API_REVERSE_PROXY))
+			options.apiReverseProxyUrl = process.env.API_REVERSE_PROXY
 
     setupProxy(options)
 


### PR DESCRIPTION
部署在海外且支持GPT访问的朋友，无需走代理，加速回复时间，不然从海外再绕回国内某某代理，再绕出海外，响应巨慢。如果是海外用户(API_REVERSE_PROXY配置)给空值即可(基本上1秒内收到回复)，国内部署的朋友，需要使用到配置里的默认值，或者改为作者推荐的那两款代理地址

Issues: #1253