### PR TITLE
feat: 新增了用户提问时审核其是否涉嫌违规的功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@ pnpm dev
 - `SOCKS_PROXY_PORT` 和 `SOCKS_PROXY_HOST` 一起时生效，可选
 - `HTTPS_PROXY` 支持 `http`，`https`, `socks5`，可选
 - `ALL_PROXY` 支持 `http`，`https`, `socks5`，可选
+- `BAIDU_API_KEY` 百度智能云应用 `API Key` [获取API Key](https://console.bce.baidu.com/ai/?_=1680831884953#/ai/antiporn/app/list)（用户提问审核功能）可选
+- `BAIDU_SECRET_KEY` 百度智能云应用 `Secret Key` [获取Secret Key](https://console.bce.baidu.com/ai/?_=1680831884953#/ai/antiporn/app/list)（用户提问审核功能）可选
+- `BAIDU_CHECK_TIPS` 文本审核不合规后的提示语 [设置审核策略](https://ai.baidu.com/censoring#/strategylist)（用户提问审核功能）可选
 
 ## 打包
 
@@ -235,9 +238,16 @@ services:
       SOCKS_PROXY_PORT: xxx
       # HTTPS 代理，可选，支持 http，https，socks5
       HTTPS_PROXY: http://xxx:7890
+      # 百度智能云应用 API Key
+      BAIDU_API_KEY: xxx
+      # 百度智能云应用 Secret Key
+      BAIDU_SECRET_KEY: xxx
+      # 文本审核不合规后的提示语，可选
+      BAIDU_CHECK_TIPS: 【xx提示】请不要问我任何涉嫌违规的内容哦！
 ```
 - `OPENAI_API_BASE_URL`  可选，设置 `OPENAI_API_KEY` 时可用
 - `OPENAI_API_MODEL`  可选，设置 `OPENAI_API_KEY` 时可用
+- `BAIDU_CHECK_TIPS`  可选，设置 `BAIDU_API_KEY` 和 `BAIDU_SECRET_KEY` 时可用
 ###  使用 Railway 部署
 
 [![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template/yytmgc)

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -28,6 +28,12 @@ services:
       SOCKS_PROXY_PORT: xxx
       # HTTPS_PROXY 代理，可选
       HTTPS_PROXY: http://xxx:7890
+      # 百度 Api Key
+      BAIDU_API_KEY:
+      # 百度 Secret Key
+      BAIDU_SECRET_KEY:
+      # 审核不合规后的提示，可选，设置 BAIDU_API_KEY 和 BAIDU_SECRET_KEY 时可用
+      BAIDU_CHECK_TIPS:
   nginx:
     image: nginx:alpine
     ports:

--- a/service/.env.example
+++ b/service/.env.example
@@ -31,3 +31,11 @@ SOCKS_PROXY_PORT=
 # HTTPS PROXY
 HTTPS_PROXY=
 
+# Baidu Api Key
+BAIDU_API_KEY=
+
+# Baidu Secret Key
+BAIDU_SECRET_KEY=
+
+# Baidu Check Tips
+BAIDU_CHECK_TIPS=

--- a/service/package.json
+++ b/service/package.json
@@ -33,6 +33,8 @@
     "https-proxy-agent": "^5.0.1",
     "isomorphic-fetch": "^3.0.0",
     "node-fetch": "^3.3.0",
+    "request": "^2.88.2",
+    "request-promise-native": "^1.0.9",
     "socks-proxy-agent": "^7.0.0"
   },
   "devDependencies": {

--- a/service/pnpm-lock.yaml
+++ b/service/pnpm-lock.yaml
@@ -14,6 +14,8 @@ specifiers:
   https-proxy-agent: ^5.0.1
   isomorphic-fetch: ^3.0.0
   node-fetch: ^3.3.0
+  request: ^2.88.2
+  request-promise-native: ^1.0.9
   rimraf: ^4.3.0
   socks-proxy-agent: ^7.0.0
   tsup: ^6.6.3
@@ -29,6 +31,8 @@ dependencies:
   https-proxy-agent: 5.0.1
   isomorphic-fetch: 3.0.0
   node-fetch: 3.3.0
+  request: registry.npmmirror.com/request/2.88.2
+  request-promise-native: registry.npmmirror.com/request-promise-native/1.0.9_request@2.88.2
   socks-proxy-agent: 7.0.0
 
 devDependencies:


### PR DESCRIPTION
考虑到一些用户会将此项目部署到公网或是公司内部使用等(避免使用者键政或其他行为)，目前增加了一个在用户对话中对提问进行审核的功能。

该功能基于百度内容审核平台，在未配置百度API Key和Secret Key的情况下，不会进行审核，后期考虑再增加针对回答进行审核的功能，预期是通过配置设置（比如模式1仅对提问进行审核，模式2仅对回答进行审核，模式3提问和回答都进行审核）。

要使用百度内容审核需要按以下步骤操作：
1.在百度智能云上创建应用。[创建应用](https://console.bce.baidu.com/ai/?_=1680831884953#/ai/antiporn/app/list)
2.将应用的API Key和Secret Key配置到chatgpt-web的配置中。
BAIDU_API_KEY: xxx
BAIDU_SECRET_KEY: xxx
BAIDU_CHECK_TIPS: 【xx提示】请不要问我任何涉嫌违规的内容哦！
注：在不配置提醒的情况下，会直接返回该文本不合规的原因。
3.可以在百度内容审核平台配置审核策略。[设置审核策略](https://ai.baidu.com/censoring#/strategylist)

效果如下：
<img width="1677" alt="image" src="https://user-images.githubusercontent.com/100349556/230529936-bca41f35-c23a-4a7c-aef8-d12a617e0ca3.png">
