### PR TITLE
fix: default return in `useLanguange()` hook

### DIFF
--- a/src/hooks/useLanguage.ts
+++ b/src/hooks/useLanguage.ts
@@ -19,7 +19,7 @@ export function useLanguage() {
         return zhTW
       default:
         setLocale('zh-CN')
-        return enUS
+        return zhCN
     }
   })
 


### PR DESCRIPTION
if `setLocale('zh-CN')`, `return` should be `zhCN`, not `enUS`.