### PR TITLE
chore: ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
+package-lock.json
 node_modules
 .DS_Store
 dist

--- a/service/.gitignore
+++ b/service/.gitignore
@@ -7,6 +7,7 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
+package-lock.json
 node_modules
 .DS_Store
 dist


### PR DESCRIPTION
本地配置环境以后会自动在对应目录下创建`package-lock.json`，而此文件并不需要加入版本控制