### PR TITLE
fix(avatar): Change the default avatar link to Introduced in Project

### DIFF
--- a/src/locales/ko-KR.ts
+++ b/src/locales/ko-KR.ts
@@ -88,6 +88,6 @@ export default {
     importError: '키 값 불일치',
     importRepeatTitle: '제목이 반복되어 건너뜀: {msg}',
     importRepeatContent: '내용이 반복되어 건너뜀: {msg}',
-    onlineImportWarning: '참고: JSON 파일 소스를 확인하십시오!',    
+    onlineImportWarning: '참고: JSON 파일 소스를 확인하십시오!',
   },
 }

--- a/src/store/modules/user/helper.ts
+++ b/src/store/modules/user/helper.ts
@@ -15,7 +15,7 @@ export interface UserState {
 export function defaultSetting(): UserState {
   return {
     userInfo: {
-      avatar: 'https://raw.githubusercontent.com/Chanzhaoyu/chatgpt-web/main/src/assets/avatar.jpg',
+      avatar: new URL('@/assets/avatar.jpg', import.meta.url).href,
       name: 'ChenZhaoYu',
       description: 'Star on <a href="https://github.com/Chanzhaoyu/chatgpt-bot" class="text-blue-500" target="_blank" >GitHub</a>',
     },


### PR DESCRIPTION
https://raw.githubusercontent.com/Chanzhaoyu/chatgpt-web/main/src/assets/avatar.jpg 

这个头像链接改为

`new URL('@/assets/avatar.jpg', import.meta.url).hre`

引入项目中的静态图片资源。

原来的头像链接可能会出现访问不了的情况

![image](https://user-images.githubusercontent.com/32154293/232291471-41de255c-6130-442d-94b8-9004f0f150c6.png)


