### PR TITLE
feat: add [when starts] option

### DIFF
--- a/src/components/common/Setting/General.vue
+++ b/src/components/common/Setting/General.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { computed, ref } from 'vue'
 import { NButton, NInput, NPopconfirm, NSelect, useMessage } from 'naive-ui'
-import type { Language, Theme } from '@/store/modules/app/helper'
+import type { Language, StartsOption, Theme } from '@/store/modules/app/helper'
 import { SvgIcon } from '@/components/common'
 import { useAppStore, useUserStore } from '@/store'
 import type { UserInfo } from '@/store/modules/user/helper'
@@ -34,6 +34,20 @@ const language = computed({
     appStore.setLanguage(value)
   },
 })
+
+const whenStarts = computed({
+  get() {
+    return appStore.whenStarts
+  },
+  set(value: StartsOption) {
+    appStore.setStartsOption(value)
+  },
+})
+
+const startsOptions: { label: string; key: StartsOption; value: StartsOption }[] = [
+  { label: 'last chat', key: 'last', value: 'last' },
+  { label: 'new chat', key: 'new', value: 'new' },
+]
 
 const themeOptions: { label: string; key: Theme; icon: string }[] = [
   {
@@ -211,6 +225,17 @@ function handleImportButtonClick(): void {
             :value="language"
             :options="languageOptions"
             @update-value="value => appStore.setLanguage(value)"
+          />
+        </div>
+      </div>
+      <div class="flex items-center space-x-4">
+        <span class="flex-shrink-0 w-[100px]">{{ $t('setting.whenStarts') }}</span>
+        <div class="flex flex-wrap items-center gap-4">
+          <NSelect
+            style="width: 140px"
+            :value="whenStarts"
+            :options="startsOptions"
+            @update-value="value => appStore.setStartsOption(value)"
           />
         </div>
       </div>

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -72,6 +72,7 @@ export default {
     httpsProxy: 'HTTPS Proxy',
     balance: 'API Balance',
     monthlyUsage: 'Monthly Usage',
+    whenStarts: 'When Starts',
   },
   store: {
     siderButton: 'Prompt Store',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -72,6 +72,7 @@ export default {
     httpsProxy: 'HTTPS Proxy',
     balance: 'API余额',
     monthlyUsage: '本月使用量',
+    whenStarts: '启动时打开',
   },
   store: {
     siderButton: '提示词商店',

--- a/src/store/modules/app/helper.ts
+++ b/src/store/modules/app/helper.ts
@@ -6,14 +6,17 @@ export type Theme = 'light' | 'dark' | 'auto'
 
 export type Language = 'zh-CN' | 'zh-TW' | 'en-US' | 'ko-KR' | 'ru-RU'
 
+export type StartsOption = 'new' | 'last'
+
 export interface AppState {
   siderCollapsed: boolean
   theme: Theme
   language: Language
+  whenStarts: StartsOption
 }
 
 export function defaultSetting(): AppState {
-  return { siderCollapsed: false, theme: 'light', language: 'zh-CN' }
+  return { siderCollapsed: false, theme: 'light', language: 'zh-CN', whenStarts: 'last' }
 }
 
 export function getLocalSetting(): AppState {

--- a/src/store/modules/app/index.ts
+++ b/src/store/modules/app/index.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import type { AppState, Language, Theme } from './helper'
+import type { AppState, Language, StartsOption, Theme } from './helper'
 import { getLocalSetting, setLocalSetting } from './helper'
 import { store } from '@/store'
 
@@ -19,6 +19,13 @@ export const useAppStore = defineStore('app-store', {
     setLanguage(language: Language) {
       if (this.language !== language) {
         this.language = language
+        this.recordState()
+      }
+    },
+    
+    setStartsOption(option: StartsOption) {
+      if (this.whenStarts !== option) {
+        this.whenStarts = option
         this.recordState()
       }
     },

--- a/src/store/modules/chat/index.ts
+++ b/src/store/modules/chat/index.ts
@@ -20,6 +20,14 @@ export const useChatStore = defineStore('chat-store', {
         return state.chat.find(item => item.uuid === state.active)?.data ?? []
       }
     },
+    
+    isCurrentNew() {
+      if (this.history.length === 0)
+        return true
+      if (this.history[0].title === 'New Chat')
+        return true
+      return false
+    },
   },
 
   actions: {

--- a/src/views/chat/layout/sider/index.vue
+++ b/src/views/chat/layout/sider/index.vue
@@ -16,6 +16,10 @@ const show = ref(false)
 
 const collapsed = computed(() => appStore.siderCollapsed)
 
+if (appStore.whenStarts === 'new' && !chatStore.isCurrentNew) {
+  handleAdd()
+}
+
 function handleAdd() {
   chatStore.addHistory({ title: 'New Chat', uuid: Date.now(), isEdit: false })
   if (isMobile.value)


### PR DESCRIPTION
# Description
在实际使用的过程中，在完成一次对话关闭页面后，再次打开的时候希望新建一个聊天而不是使用上一次的聊天，这个PR在设置页面增加了一个`When Starts`选项，这个选项可以设置在重新打开页面时是使用新的聊天还是用上一次的聊天：
- `last chat`: 使用上一次聊天（默认）
- `new chat`: 新建聊天

# Test
![when_starts_option](https://user-images.githubusercontent.com/13044805/236222390-2df5e0cb-1761-417f-946a-8a21f0b5b0f0.png)

