### PR TITLE
<fix> Docker镜像构建失败

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build front-end
-FROM node:lts-alpine AS frontend
+FROM node:16-alpine3.16 AS frontend
 
 RUN npm install pnpm -g
 
@@ -16,7 +16,7 @@ COPY . /app
 RUN pnpm run build
 
 # build backend
-FROM node:lts-alpine as backend
+FROM node:16-alpine3.16 as backend
 
 RUN npm install pnpm -g
 
@@ -33,7 +33,7 @@ COPY /service /app
 RUN pnpm build
 
 # service
-FROM node:lts-alpine
+FROM node:16-alpine3.16
 
 RUN npm install pnpm -g
 


### PR DESCRIPTION
<fix> Docker镜像构建失败

 > [frontend 6/8] RUN pnpm install:
#0 0.375 ERROR: This version of pnpm requires at least Node.js v16.14 #0 0.375 The current version of Node.js is v16.13.1 #0 0.375 Visit https://r.pnpm.io/comp to see the list of past pnpm versions with respective Node.js version support.
 > [backend 6/8] RUN pnpm install:                                                                                                                         
#0 0.394 ERROR: This version of pnpm requires at least Node.js v16.14                                                                                       #0 0.394 The current version of Node.js is v16.13.1                                                                                                         #0 0.394 Visit https://r.pnpm.io/comp to see the list of past pnpm versions with respective Node.js version support.                                        ------                                                                                                                                                      ------
 > [stage-2 6/9] RUN pnpm install --production && rm -rf /root/.npm /root/.pnpm-store /usr/local/share/.cache /tmp/*:
#0 0.404 ERROR: This version of pnpm requires at least Node.js v16.14 #0 0.404 The current version of Node.js is v16.13.1 #0 0.404 Visit https://r.pnpm.io/comp to see the list of past pnpm versions with respective Node.js version support.