### PR TITLE
导入聊天记录从覆盖记录改为合并记录

### DIFF
--- a/src/components/common/Setting/General.vue
+++ b/src/components/common/Setting/General.vue
@@ -182,7 +182,7 @@ function handleImportButtonClick(): void {
             <template #icon>
               <SvgIcon icon="ri:upload-2-fill" />
             </template>
-            {{ $t('common.import') }}
+            {{ $t('common.mergeImport') }}
           </NButton>
 
           <NPopconfirm placement="bottom" @positive-click="clearData">

--- a/src/components/common/Setting/General.vue
+++ b/src/components/common/Setting/General.vue
@@ -99,7 +99,17 @@ function importData(event: Event): void {
   reader.onload = () => {
     try {
       const data = JSON.parse(reader.result as string)
-      localStorage.setItem('chatStorage', JSON.stringify(data))
+      // 合并历史聊天记录：去重合并data.history数组data.chat数组到原聊天记录列表
+      // 获取原聊天数据
+      const originalData = JSON.parse(localStorage.getItem('chatStorage') || '{}')
+      // 去重合并history
+      originalData.data.history = [...originalData.data.history, ...data.data.history]
+        .filter((item, index, arr) => arr.findIndex(i => i.uuid === item.uuid) === index)
+      // 去重合并chat
+      originalData.data.chat = [...originalData.data.chat, ...data.data.chat]
+        .filter((item, index, arr) => arr.findIndex(i => i.uuid === item.uuid) === index)
+      // 更新本地存储
+      localStorage.setItem('chatStorage', JSON.stringify(originalData))
       ms.success(t('common.success'))
       location.reload()
     }

--- a/src/components/common/Setting/General.vue
+++ b/src/components/common/Setting/General.vue
@@ -111,7 +111,7 @@ function importData(event: Event): void {
         .filter((item, index, arr) => arr.findIndex(i => i.uuid === item.uuid) === index)
       // 更新本地存储
       chatStore.recordState()
-      ms.success(t('common.success'))
+      ms.success(t('common.importSuccess'))
       location.reload()
     }
     catch (error) {

--- a/src/components/common/Setting/General.vue
+++ b/src/components/common/Setting/General.vue
@@ -3,13 +3,14 @@ import { computed, ref } from 'vue'
 import { NButton, NInput, NPopconfirm, NSelect, useMessage } from 'naive-ui'
 import type { Language, Theme } from '@/store/modules/app/helper'
 import { SvgIcon } from '@/components/common'
-import { useAppStore, useUserStore } from '@/store'
+import { useAppStore, useChatStore, useUserStore } from '@/store'
 import type { UserInfo } from '@/store/modules/user/helper'
 import { getCurrentDate } from '@/utils/functions'
 import { useBasicLayout } from '@/hooks/useBasicLayout'
 import { t } from '@/locales'
 
 const appStore = useAppStore()
+const chatStore = useChatStore()
 const userStore = useUserStore()
 
 const { isMobile } = useBasicLayout()
@@ -98,18 +99,18 @@ function importData(event: Event): void {
   const reader: FileReader = new FileReader()
   reader.onload = () => {
     try {
-      const data = JSON.parse(reader.result as string)
+      const data = JSON.parse(reader.result as string).data
       // 合并历史聊天记录：去重合并data.history数组data.chat数组到原聊天记录列表
       // 获取原聊天数据
-      const originalData = JSON.parse(localStorage.getItem('chatStorage') || '{}')
+      const originalData = chatStore.$state
       // 去重合并history
-      originalData.data.history = [...originalData.data.history, ...data.data.history]
+      originalData.history = [...originalData.history, ...data.history]
         .filter((item, index, arr) => arr.findIndex(i => i.uuid === item.uuid) === index)
       // 去重合并chat
-      originalData.data.chat = [...originalData.data.chat, ...data.data.chat]
+      originalData.chat = [...originalData.chat, ...data.chat]
         .filter((item, index, arr) => arr.findIndex(i => i.uuid === item.uuid) === index)
       // 更新本地存储
-      localStorage.setItem('chatStorage', JSON.stringify(originalData))
+      chatStore.recordState()
       ms.success(t('common.success'))
       location.reload()
     }

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -13,6 +13,7 @@ export default {
     export: 'Export',
     exportSuccess: 'Export Success',
     import: 'Import',
+    mergeImport: 'Merge Import',
     importSuccess: 'Import Success',
     clear: 'Clear',
     clearSuccess: 'Clear Success',
@@ -26,7 +27,7 @@ export default {
     failed: 'Failed',
     verify: 'Verify',
     unauthorizedTips: 'Unauthorized, please verify first.',
-		stopResponding: 'Stop Responding',
+    stopResponding: 'Stop Responding',
   },
   chat: {
     newChatButton: 'New Chat',

--- a/src/locales/ko-KR.ts
+++ b/src/locales/ko-KR.ts
@@ -13,6 +13,7 @@ export default {
     export: '내보내기',
     exportSuccess: '내보내기 성공',
     import: '가져오기',
+    mergeImport: '병합 가져오기',
     importSuccess: '가져오기 성공',
     clear: '비우기',
     clearSuccess: '비우기 성공',
@@ -26,7 +27,7 @@ export default {
     failed: '실패',
     verify: '검증',
     unauthorizedTips: '인증되지 않았습니다. 먼저 확인하십시오.',
-		stopResponding: '응답 중지',
+    stopResponding: '응답 중지',
   },
   chat: {
     newChatButton: '새로운 채팅',

--- a/src/locales/ru-RU.ts
+++ b/src/locales/ru-RU.ts
@@ -13,6 +13,7 @@ export default {
     export: 'Экспортировать',
     exportSuccess: 'Экспорт выполнен успешно',
     import: 'Импортировать',
+    mergeImport: 'Объединить импорт',
     importSuccess: 'Импорт выполнен успешно',
     clear: 'Очистить',
     clearSuccess: 'Очищено успешно',
@@ -26,7 +27,7 @@ export default {
     failed: 'Не удалось',
     verify: 'Проверить',
     unauthorizedTips: 'Не авторизован, сначала подтвердите свою личность.',
-		stopResponding: 'Прекращение отклика',
+    stopResponding: 'Прекращение отклика',
   },
   chat: {
     newChatButton: 'Новый чат',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -13,6 +13,7 @@ export default {
     export: '导出',
     exportSuccess: '导出成功',
     import: '导入',
+    mergeImport: '合并导入',
     importSuccess: '导入成功',
     clear: '清空',
     clearSuccess: '清空成功',
@@ -26,7 +27,7 @@ export default {
     failed: '操作失败',
     verify: '验证',
     unauthorizedTips: '未经授权，请先进行验证。',
-		stopResponding: '停止响应',
+    stopResponding: '停止响应',
   },
   chat: {
     newChatButton: '新建聊天',

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -13,6 +13,7 @@ export default {
     export: '匯出',
     exportSuccess: '匯出成功',
     import: '匯入',
+    mergeImport: '合併匯入',
     importSuccess: '匯入成功',
     clear: '清除',
     clearSuccess: '清除成功',
@@ -26,7 +27,7 @@ export default {
     failed: '操作失敗',
     verify: '驗證',
     unauthorizedTips: '未經授權，請先進行驗證。',
-		stopResponding: '終止回應',
+    stopResponding: '終止回應',
   },
   chat: {
     newChatButton: '新增對話',


### PR DESCRIPTION
关联 https://github.com/Chanzhaoyu/chatgpt-web/issues/1463

修改为去重合并`history`数组`chat`数组。

去重规则：数组元素`uuid`一致时保留原记录（浏览器localStorage）中的元素。

---

已知问题：第一个聊天记录的`uuid`为何要是固定值`1002`？（关联commit: 50e672e79b76d27c2185970929cf44fb16595507）

https://github.com/Chanzhaoyu/chatgpt-web/blob/bc390ef09deb391c8d3f5a16aa9c45cc44082818/src/store/modules/chat/helper.ts#L6

暂未处理`uuid`是1002的情况，如果原记录和外部文件都存在1002，只会保留原记录中`uuid`为`1002`的元素

---

另外根据[贡献指南](https://github.com/Chanzhaoyu/chatgpt-web/pull/CONTRIBUTING.md)：

执行`pnpm`后命令后，仓库`pnpm-lock.yaml`文件被修改，本人非前端开发人员，因此不确定是否需要提交此更改。

