### PR TITLE
fix: 多层代理导致ip获取错误,限流失效

### DIFF
--- a/service/.eslintrc.json
+++ b/service/.eslintrc.json
@@ -1,5 +1,8 @@
 {
   "root": true,
   "ignorePatterns": ["build"],
-  "extends": ["@antfu"]
+  "extends": ["@antfu"],
+  "rules": {
+    "@typescript-eslint/no-var-requires": 0
+  }
 }

--- a/service/package.json
+++ b/service/package.json
@@ -33,6 +33,7 @@
     "https-proxy-agent": "^5.0.1",
     "isomorphic-fetch": "^3.0.0",
     "node-fetch": "^3.3.0",
+    "request-ip": "^3.3.0",
     "socks-proxy-agent": "^7.0.0"
   },
   "devDependencies": {

--- a/service/src/index.ts
+++ b/service/src/index.ts
@@ -84,6 +84,5 @@ router.post('/verify', async (req, res) => {
 
 app.use('', router)
 app.use('/api', router)
-app.set('trust proxy', 1)
 
 app.listen(3002, () => globalThis.console.log('Server is running on port 3002'))

--- a/service/src/middleware/limiter.ts
+++ b/service/src/middleware/limiter.ts
@@ -1,5 +1,6 @@
 import { rateLimit } from 'express-rate-limit'
 import { isNotEmptyString } from '../utils/is'
+const requestIp = require('request-ip')
 
 const MAX_REQUEST_PER_HOUR = process.env.MAX_REQUEST_PER_HOUR
 
@@ -11,6 +12,9 @@ const limiter = rateLimit({
   windowMs: 60 * 60 * 1000, // Maximum number of accesses within an hour
   max: maxCount,
   statusCode: 200, // 200 means success，but the message is 'Too many request from this IP in 1 hour'
+  keyGenerator: (req, _) => {
+    return requestIp.getClientIp(req) // IP address from requestIp.mw(), as opposed to req.ip
+  },
   message: async (req, res) => {
     res.send({ status: 'Fail', message: 'Too many request from this IP in 1 hour', data: null })
   },


### PR DESCRIPTION
app.set('trust proxy', 1)，这里的1是用户和服务器之间的代理数，在cdn+nginx反代(多层代理)情况下可能会失效，引入[request-ip](https://www.npmjs.com/package/request-ip?activeTab=readme)解决ip获取错误导致限流失效。