### PR TITLE
fix: 修复 html2canvas 生成截图文字向下漂移

### DIFF
--- a/src/styles/lib/tailwind.css
+++ b/src/styles/lib/tailwind.css
@@ -1,3 +1,8 @@
 @tailwind base;
+@layer base {
+	img {
+		@apply inline-block;
+	}
+}
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
前后对比

### 修复前
![修复前](https://github.com/Chanzhaoyu/chatgpt-web/assets/18721016/8261f1d9-d2a8-4c74-bde7-696f883a288a)

### 修复后
![修复后](https://github.com/Chanzhaoyu/chatgpt-web/assets/18721016/2d0adb25-3f3a-494e-9727-8b7ad17ec9ae)
