### PR TITLE
feat: support the latest GPT-4 Turbo (gpt-4-1106-preview) model

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ services:
       # API接口地址，可选，设置 OPENAI_API_KEY 时可用
       OPENAI_API_BASE_URL: xxx
       # API模型，可选，设置 OPENAI_API_KEY 时可用，https://platform.openai.com/docs/models
-      # gpt-4, gpt-4-0314, gpt-4-0613, gpt-4-32k, gpt-4-32k-0314, gpt-4-32k-0613, gpt-3.5-turbo-16k, gpt-3.5-turbo-16k-0613, gpt-3.5-turbo, gpt-3.5-turbo-0301, gpt-3.5-turbo-0613, text-davinci-003, text-davinci-002, code-davinci-002
+      # gpt-4, gpt-4-1106-preview, gpt-4-0314, gpt-4-0613, gpt-4-32k, gpt-4-32k-0314, gpt-4-32k-0613, gpt-3.5-turbo-16k, gpt-3.5-turbo-16k-0613, gpt-3.5-turbo, gpt-3.5-turbo-0301, gpt-3.5-turbo-0613, text-davinci-003, text-davinci-002, code-davinci-002
       OPENAI_API_MODEL: xxx
       # 反向代理，可选
       API_REVERSE_PROXY: xxx

--- a/service/src/chatgpt/index.ts
+++ b/service/src/chatgpt/index.ts
@@ -53,6 +53,11 @@ let api: ChatGPTAPI | ChatGPTUnofficialProxyAPI
         options.maxModelTokens = 32768
         options.maxResponseTokens = 8192
       }
+      // if use GPT-4 Turbo
+      else if (model.toLowerCase().includes('1106-preview')) {
+        options.maxModelTokens = 128000
+        options.maxResponseTokens = 4096
+      }
       else {
         options.maxModelTokens = 8192
         options.maxResponseTokens = 2048


### PR DESCRIPTION
Add the latest and powerful `gpt-4-1106-preview` model with 128k context window(but the output is limited to 4k tokens), training data to Apr 2023, and the turbo speed :zap: 

Reference:
- https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo
- https://openai.com/blog/new-models-and-developer-products-announced-at-devday#gpt-4-turbo-with-128k-context