### PR TITLE
set pnpm version to 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # build front-end
 FROM node:lts-alpine AS frontend
 
-RUN npm install pnpm -g
+RUN npm install pnpm@7 -g
 
 WORKDIR /app
 
@@ -18,7 +18,7 @@ RUN pnpm run build
 # build backend
 FROM node:lts-alpine as backend
 
-RUN npm install pnpm -g
+RUN npm install pnpm@7 -g
 
 WORKDIR /app
 
@@ -35,7 +35,7 @@ RUN pnpm build
 # service
 FROM node:lts-alpine
 
-RUN npm install pnpm -g
+RUN npm install pnpm@7 -g
 
 WORKDIR /app
 


### PR DESCRIPTION
Fix the issue:
0.407 ERROR: This version of pnpm requires at least Node.js v16.14
0.407 The current version of Node.js is v16.13.1