### PR TITLE
feat: improve GPT-3.5 Turbo 16k support

### DIFF
--- a/service/src/chatgpt/index.ts
+++ b/service/src/chatgpt/index.ts
@@ -64,7 +64,7 @@ let api: ChatGPTAPI | ChatGPTUnofficialProxyAPI
       }
     }
     else if (model.toLowerCase().includes('gpt-3.5')) {
-      if (model.toLowerCase().includes('16k')) {
+      if (/16k|1106|0125/.test(model.toLowerCase())) {
         options.maxModelTokens = 16384
         options.maxResponseTokens = 4096
       }


### PR DESCRIPTION
GPT-3.5 models with the "16k" suffix are all marked as `Legacy` now. The latest models use prefixes like 0125 and 0613, and all support a 16k context window with 4k output.

Reference:
- https://platform.openai.com/docs/models/gpt-3-5-turbo