### PR TITLE
chore: replace EOL Node.js v19 w/ LTS v20 in engine spec

### DIFF
--- a/service/package-lock.json
+++ b/service/package-lock.json
@@ -29,7 +29,7 @@
         "typescript": "^4.9.5"
       },
       "engines": {
-        "node": "^16 || ^18 || ^19"
+        "node": "^16 || ^18 || ^20"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/service/package.json
+++ b/service/package.json
@@ -11,7 +11,7 @@
     "express"
   ],
   "engines": {
-    "node": "^16 || ^18 || ^19"
+    "node": "^16 || ^18 || ^20"
   },
   "scripts": {
     "start": "esno ./src/index.ts",


### PR DESCRIPTION
Update the Node.js engine setting in service/package.json to use LTS v20 instead of the end-of-life v19. This aligns with our Dockerfile that uses node:lts-alpine, which has been a while without issues. The update also helps suppress the runtime warnings about engine compatibility:

> WARN  Unsupported engine: wanted: {"node":"^16 || ^18 || ^19"} (current: {"node":"v20.12.2","pnpm":"9.0.4"})